### PR TITLE
typo: use refactor instead of refact cf conventional commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ List of type available:
 - Design - For design changes only (e.g., design: use rounded button)
 - Experiment - General things that should be in experiment (e.g., experiment: implement new query system in X)
 - Docs - For documentation changes only (e.g., docs: fix typo in X)
-- Refact - General things that should be restructured but not changing the original functionality (e.g., refact: move X to new file utils)
+- Refactor - General things that should be restructured but not changing the original functionality (e.g., refactor: move X to new file utils)
 - CI - For internal CI specific changes (e.g., ci: enable X for tests)
 - Infra - For infrastructure changes (e.g., infra: Enable cloudfront for X)
 - Test - For changes to tests only (e.g., test: check if X does Y)

--- a/src/helpers/prompts.ts
+++ b/src/helpers/prompts.ts
@@ -33,8 +33,8 @@ export async function typePrompt() {
         value: 'docs',
       },
       {
-        name: 'Refact - General things that should be restructured but not changing the original functionality (e.g., refact: move X to new file utils)',
-        value: 'refact',
+        name: 'Refactor - General things that should be restructured but not changing the original functionality (e.g., refactor: move X to new file utils)',
+        value: 'refactor',
       },
       {
         name: 'CI - For internal CI specific changes (e.g., ci: enable X for tests)',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected the spelling of "Refact" to "Refactor" in the README for clarity and consistency.
  
- **New Features**
	- Updated the commit type selection prompt to standardize the terminology for the refactoring option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->